### PR TITLE
fix: include <cfloat> in simple_knn.cu to resolve FLT_MAX compilation error

### DIFF
--- a/gaussian_splatting/submodules/simple-knn/simple_knn.cu
+++ b/gaussian_splatting/submodules/simple-knn/simple_knn.cu
@@ -23,6 +23,7 @@
 #define __CUDACC__
 #include <cooperative_groups.h>
 #include <cooperative_groups/reduce.h>
+#include <cfloat>
 
 namespace cg = cooperative_groups;
 


### PR DESCRIPTION
Added header to simple_knn.cu to define FLT_MAX and other floating-point constants needed for CUDA compatibility. This change addresses build errors encountered during compilation with nvcc when FLT_MAX was undefined.