### PR TITLE
delete extension of an image used to create a image path

### DIFF
--- a/sugar_scene/cameras.py
+++ b/sugar_scene/cameras.py
@@ -95,7 +95,7 @@ def load_gs_cameras(source_path, gs_output_path, image_resolution=1,
         # GT data
         id = camera_transform['id']
         name = camera_transform['img_name']
-        image_path = os.path.join(image_dir,  name + extension)
+        image_path = os.path.join(image_dir,  name)
         
         if load_gt_images:
             image = Image.open(image_path)


### PR DESCRIPTION
I don't think it is necessary to add an extension to the image path as the extension is already included in camera.json. So, I simply deleted extension used to create an image path. 

At least in my output of gaussian splatting, it is already included. Thus, adding the path could cause file not found error. 